### PR TITLE
feat: use all graph node struct fields as attributes

### DIFF
--- a/pkg/fetcher/stars/stars.go
+++ b/pkg/fetcher/stars/stars.go
@@ -36,7 +36,7 @@ func (f *Fetcher) GetTotalPages(ctx context.Context, paging int) (int, error) {
 		},
 	}
 
-	_, resp, err := client.Activity.ListStarred(context.Background(), f.user, opts)
+	_, resp, err := client.Activity.ListStarred(ctx, f.user, opts)
 	if err != nil {
 		return 0, err
 	}
@@ -60,7 +60,7 @@ func (f *Fetcher) Fetch(ctx context.Context, startPage, endPage int, reposChan c
 			},
 		}
 
-		repos, _, err := client.Activity.ListStarred(context.Background(), "", opts)
+		repos, _, err := client.Activity.ListStarred(ctx, "", opts)
 		if err != nil {
 			return fmt.Errorf("error fetching page %d: %v", page, err)
 		}

--- a/pkg/graph/api/edge.go
+++ b/pkg/graph/api/edge.go
@@ -22,7 +22,7 @@ type Edge struct {
 type EdgeService interface {
 	// CreateEdge creates a new edge.
 	CreateEdge(ctx context.Context, uid string, e *Edge) error
-	// FindEdgeByUID returns a single edge with the given id.
+	// FindEdgeByUID returns a single edge with the given uid.
 	FindEdgeByUID(ctx context.Context, guid, euid string) (*Edge, error)
 	// FindEdges returns all edges matching the filter.
 	// It also returns a count of total matching edges which may differ from

--- a/pkg/graph/builder/stars/attrs.go
+++ b/pkg/graph/builder/stars/attrs.go
@@ -2,49 +2,20 @@ package stars
 
 import (
 	"github.com/google/go-github/v61/github"
+	"github.com/milosgajdos/orbnet/pkg/graph/attrs"
 )
 
-func OwnerAttrs(owner *github.User) map[string]interface{} {
-	attrs := map[string]interface{}{
-		"name":              owner.Login,
-		"type":              owner.Type,
-		"url":               owner.URL,
-		"html_url":          owner.HTMLURL,
-		"repos_url":         owner.ReposURL,
-		"followers":         owner.Followers,
-		"followers_url":     owner.FollowersURL,
-		"following":         owner.Following,
-		"following_url":     owner.FollowingURL,
-		"starred_url":       owner.StarredURL,
-		"created_at":        owner.CreatedAt,
-		"updated_at":        owner.UpdatedAt,
-		"collaborators":     owner.Collaborators,
-		"organizations_url": owner.OrganizationsURL,
-	}
-	return attrs
+func OwnerAttrs(owner *github.User) (map[string]interface{}, error) {
+	return attrs.Encode(owner)
 }
 
-func RepoAttrs(repo *github.Repository, starredAt *github.Timestamp) map[string]interface{} {
-	attrs := map[string]interface{}{
-		"name":              repo.Name,
-		"full_name":         repo.FullName,
-		"visibility":        repo.Visibility,
-		"archived":          repo.Archived,
-		"starred_at":        starredAt,
-		"created_at":        repo.CreatedAt,
-		"pushed_at":         repo.PushedAt,
-		"updated_at":        repo.UpdatedAt,
-		"html_url":          repo.HTMLURL,
-		"forks_url":         repo.ForksURL,
-		"languages_url":     repo.LanguagesURL,
-		"collaborators_url": repo.CollaboratorsURL,
-		"stargazers_count":  repo.StargazersCount,
-		"stargazers_url":    repo.StargazersURL,
+func RepoAttrs(repo *github.Repository, starredAt *github.Timestamp) (map[string]interface{}, error) {
+	attrs, err := attrs.Encode(repo)
+	if err != nil {
+		return nil, err
 	}
-	if repo.License != nil {
-		attrs["license"] = repo.License.Name
-	}
-	return attrs
+	attrs["starred_at"] = starredAt
+	return attrs, nil
 }
 
 func TopicAttrs(topic string) map[string]interface{} {
@@ -58,7 +29,6 @@ func TopicAttrs(topic string) map[string]interface{} {
 func LangAttrs(lang string) map[string]interface{} {
 	attrs := map[string]interface{}{
 		"name": lang,
-		"url":  "https://github.com/trending/" + lang,
 	}
 	return attrs
 }

--- a/pkg/graph/builder/stars/stars.go
+++ b/pkg/graph/builder/stars/stars.go
@@ -85,7 +85,10 @@ func (s *Stars) update(repos []*github.StarredRepository) (err error) {
 		if !ok {
 			style := OwnerEntity.DefaultStyle()
 			label := OwnerEntity.String()
-			attrs := OwnerAttrs(repo.Repository.Owner)
+			attrs, err := OwnerAttrs(repo.Repository.Owner)
+			if err != nil {
+				return err
+			}
 			ownerNode, err = s.addNode(uid, label, attrs, style)
 			if err != nil {
 				return err
@@ -98,7 +101,10 @@ func (s *Stars) update(repos []*github.StarredRepository) (err error) {
 		if !ok {
 			style := RepoEntity.DefaultStyle()
 			label := RepoEntity.String()
-			attrs := RepoAttrs(repo.Repository, repo.StarredAt)
+			attrs, err := RepoAttrs(repo.Repository, repo.StarredAt)
+			if err != nil {
+				return err
+			}
 			repoNode, err = s.addNode(uid, label, attrs, style)
 			if err != nil {
 				return err


### PR DESCRIPTION
We've added `Encode` function to `attrs` package that turns all exported struct fields into attributes.